### PR TITLE
Cleanup the various .NET benchmarks

### DIFF
--- a/NET_project/Benchmarks/Fibonacci.cs
+++ b/NET_project/Benchmarks/Fibonacci.cs
@@ -8,7 +8,7 @@ public struct FibonacciNET : IJob {
 		result = Fibonacci(number);
 	}
 
-	private uint Fibonacci(uint number) {
+	private static uint Fibonacci(uint number) {
 		if (number <= 1)
 			return 1;
 

--- a/NET_project/Benchmarks/Mandelbrot.cs
+++ b/NET_project/Benchmarks/Mandelbrot.cs
@@ -10,18 +10,19 @@ public struct MandelbrotNET : IJob {
 		result = Mandelbrot(width, height, iterations);
 	}
 
-	private float Mandelbrot(uint width, uint height, uint iterations) {
+	private static float Mandelbrot(uint width, uint height, uint iterations) {
+		const float left = -2.1f;
+		const float right = 1.0f;
+		const float top = -1.3f;
+		const float bottom = 1.3f;
+
+		float deltaX = (right - left) / width;
+		float deltaY = (bottom - top) / height;
+
 		float data = 0.0f;
 
 		for (uint i = 0; i < iterations; i++) {
-			float
-				left = -2.1f,
-				right = 1.0f,
-				top = -1.3f,
-				bottom = 1.3f,
-				deltaX = (right - left) / width,
-				deltaY = (bottom - top) / height,
-				coordinateX = left;
+			float coordinateX = left;
 
 			for (uint x = 0; x < width; x++) {
 				float coordinateY = top;
@@ -31,12 +32,12 @@ public struct MandelbrotNET : IJob {
 					float workY = 0;
 					int counter = 0;
 
-					while (counter < 255 && Math.Sqrt((workX * workX) + (workY * workY)) < 2.0f) {
+					while (counter < 255 && float.Sqrt((workX * workX) + (workY * workY)) < 2.0f) {
 						counter++;
 
 						float newX = (workX * workX) - (workY * workY) + coordinateX;
 
-						workY = 2 * workX * workY + coordinateY;
+						workY = (2 * workX * workY) + coordinateY;
 						workX = newX;
 					}
 

--- a/NET_project/Benchmarks/NBody.cs
+++ b/NET_project/Benchmarks/NBody.cs
@@ -31,9 +31,8 @@ public unsafe struct NBodyNET : IJob {
 	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	private void InitializeBodies(NBody* sun, NBody* end) {
-		const double pi = 3.141592653589793;
-		const double solarMass = 4 * pi * pi;
+	private static void InitializeBodies(NBody* sun, NBody* end) {
+		const double solarMass = 4 * double.Pi * double.Pi;
 		const double daysPerYear = 365.24;
 
 		unchecked {
@@ -79,7 +78,7 @@ public unsafe struct NBodyNET : IJob {
 
 			double vx = 0, vy = 0, vz = 0;
 
-			for (NBody* planet = sun + 1; planet <= end; ++planet) {
+			for (NBody* planet = sun + 1; planet <= end; planet++) {
 				double mass = planet->mass;
 
 				vx += planet->vx * mass;
@@ -95,83 +94,75 @@ public unsafe struct NBodyNET : IJob {
 	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	private void Energy(NBody* sun, NBody* end) {
-		unchecked {
-			double e = 0.0;
+	private static void Energy(NBody* sun, NBody* end) {
+		double e = 0.0;
 
-			for (NBody* bi = sun; bi <= end; ++bi) {
-				double
-					imass = bi->mass,
-					ix = bi->x,
-					iy = bi->y,
-					iz = bi->z,
-					ivx = bi->vx,
-					ivy = bi->vy,
-					ivz = bi->vz;
+		for (NBody* bi = sun; bi <= end; bi++) {
+			double imass = bi->mass;
+			double ix = bi->x;
+			double iy = bi->y;
+			double iz = bi->z;
+			double ivx = bi->vx;
+			double ivy = bi->vy;
+			double ivz = bi->vz;
 
-				e += 0.5 * imass * (ivx * ivx + ivy * ivy + ivz * ivz);
+			e += 0.5 * imass * ((ivx * ivx) + (ivy * ivy) + (ivz * ivz));
 
-				for (NBody* bj = bi + 1; bj <= end; ++bj) {
-					double
-						jmass = bj->mass,
-						dx = ix - bj->x,
-						dy = iy - bj->y,
-						dz = iz - bj->z;
+			for (NBody* bj = bi + 1; bj <= end; bj++) {
+				double jmass = bj->mass;
+				double dx = ix - bj->x;
+				double dy = iy - bj->y;
+				double dz = iz - bj->z;
 
-					e -= imass * jmass / Math.Sqrt(dx * dx + dy * dy + dz * dz);
-				}
+				e -= imass * jmass / double.Sqrt((dx * dx) + (dy * dy) + (dz * dz));
 			}
 		}
 	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	private double GetD2(double dx, double dy, double dz) {
-		double d2 = dx * dx + dy * dy + dz * dz;
+	private static double GetD2(double dx, double dy, double dz) {
+		double d2 = (dx * dx) + (dy * dy) + (dz * dz);
 
-		return d2 * Math.Sqrt(d2);
+		return d2 * double.Sqrt(d2);
 	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	private void Advance(NBody* sun, NBody* end, double distance) {
-		unchecked {
-			for (NBody* bi = sun; bi < end; ++bi) {
-				double
-					ix = bi->x,
-					iy = bi->y,
-					iz = bi->z,
-					ivx = bi->vx,
-					ivy = bi->vy,
-					ivz = bi->vz,
-					imass = bi->mass;
+	private static void Advance(NBody* sun, NBody* end, double distance) {
+		for (NBody* bi = sun; bi < end; bi++) {
+			double ix = bi->x;
+			double iy = bi->y;
+			double iz = bi->z;
+			double ivx = bi->vx;
+			double ivy = bi->vy;
+			double ivz = bi->vz;
+			double imass = bi->mass;
 
-				for (NBody* bj = bi + 1; bj <= end; ++bj) {
-					double
-						dx = bj->x - ix,
-						dy = bj->y - iy,
-						dz = bj->z - iz,
-						jmass = bj->mass,
-						mag = distance / GetD2(dx, dy, dz);
+			for (NBody* bj = bi + 1; bj <= end; bj++) {
+				double dx = bj->x - ix;
+				double dy = bj->y - iy;
+				double dz = bj->z - iz;
+				double jmass = bj->mass;
+				double mag = distance / GetD2(dx, dy, dz);
 
-					bj->vx = bj->vx - dx * imass * mag;
-					bj->vy = bj->vy - dy * imass * mag;
-					bj->vz = bj->vz - dz * imass * mag;
-					ivx = ivx + dx * jmass * mag;
-					ivy = ivy + dy * jmass * mag;
-					ivz = ivz + dz * jmass * mag;
-				}
-
-				bi->vx = ivx;
-				bi->vy = ivy;
-				bi->vz = ivz;
-				bi->x = ix + ivx * distance;
-				bi->y = iy + ivy * distance;
-				bi->z = iz + ivz * distance;
+				bj->vx = bj->vx - (dx * imass * mag);
+				bj->vy = bj->vy - (dy * imass * mag);
+				bj->vz = bj->vz - (dz * imass * mag);
+				ivx += dx * jmass * mag;
+				ivy += dy * jmass * mag;
+				ivz += dz * jmass * mag;
 			}
 
-			end->x = end->x + end->vx * distance;
-			end->y = end->y + end->vy * distance;
-			end->z = end->z + end->vz * distance;
+			bi->vx = ivx;
+			bi->vy = ivy;
+			bi->vz = ivz;
+			bi->x = ix + (ivx * distance);
+			bi->y = iy + (ivy * distance);
+			bi->z = iz + (ivz * distance);
 		}
+
+		end->x = end->x + (end->vx * distance);
+		end->y = end->y + (end->vy * distance);
+		end->z = end->z + (end->vz * distance);
 	}
 }
 

--- a/NET_project/Benchmarks/ParticleKinematics.cs
+++ b/NET_project/Benchmarks/ParticleKinematics.cs
@@ -1,7 +1,10 @@
-﻿namespace NET_project.Benchmarks;
+﻿using System.Numerics;
+
+namespace NET_project.Benchmarks;
 
 internal struct Particle {
-	public float x, y, z, vx, vy, vz;
+	public Vector3 i;
+	public Vector3 v;
 }
 
 public unsafe struct ParticleKinematicsNET : IJob
@@ -10,38 +13,30 @@ public unsafe struct ParticleKinematicsNET : IJob
 	public uint iterations;
 	public float result;
 
-	public void Run()
-	{
+	public void Run() {
 		result = ParticleKinematics(quantity, iterations);
 	}
 
-	private float ParticleKinematics(uint quantity, uint iterations)
-	{
+	private static float ParticleKinematics(uint quantity, uint iterations) {
 		Particle[] particles = new Particle[quantity];
 
-		for (uint i = 0; i < quantity; ++i)
-		{
-			particles[i].x = i;
-			particles[i].y = (i + 1);
-			particles[i].z = (i + 2);
-			particles[i].vx = 1.0f;
-			particles[i].vy = 2.0f;
-			particles[i].vz = 3.0f;
+		for (int i = 0; i < particles.Length; i++) {
+			particles[i].i = new Vector3(i) + new Vector3(0, 1, 2);
+			particles[i].v = new Vector3(1, 2, 3);
 		}
 
-		for (uint a = 0; a < iterations; ++a)
-		{
-			for (uint b = 0, c = quantity; b < c; ++b)
-			{
-				particles[b].x += particles[b].vx;
-				particles[b].y += particles[b].vy;
-				particles[b].z += particles[b].vz;
+		for (uint a = 0; a < iterations; a++) {
+			for (int b = 0; b < particles.Length; b++) {
+				particles[b].i += particles[b].v;
 			}
 		}
 
-		Particle particle = new Particle { x = particles[0].x, y = particles[0].y, z = particles[0].z };
-
-		return particle.x + particle.y + particle.z;
+		if (particles.Length == 0)
+		{
+			// Help the JIT by testing for quantity == 0
+			return default;
+		}
+		return particles[0].i.X + particles[0].i.Y + particles[0].i.Z;
 	}
 }
 

--- a/NET_project/Benchmarks/PixarRaytracer.cs
+++ b/NET_project/Benchmarks/PixarRaytracer.cs
@@ -17,49 +17,42 @@ public unsafe struct PixarRaytracerNET : IJob
 	public uint samples;
 	public float result;
 
-	public void Run()
-	{
+	public void Run() {
 		result = PixarRaytracer(width, height, samples);
 	}
 
-	private uint marsagliaZ, marsagliaW;
+	private static uint marsagliaZ;
+	private static uint marsagliaW;
 
-	private float PixarRaytracer(uint width, uint height, uint samples)
+	private static float PixarRaytracer(uint width, uint height, uint samples)
 	{
 		marsagliaZ = 666;
 		marsagliaW = 999;
 
-		Vector3 position = new Vector3 { X = -22.0f, Y = 5.0f, Z = 25.0f };
-		Vector3 goal = new Vector3 { X = -3.0f, Y = 4.0f, Z = 0.0f };
+		Vector3 position = new Vector3(-22.0f, 5.0f, 25.0f);
+		Vector3 goal = new Vector3(-3.0f, 4.0f, 0.0f);
 
-		goal = Vector3.Add(Inverse(goal), Vector3.Multiply(position, -1.0f));
+		goal = Vector3.Normalize(goal) - position;
 
-		Vector3 left = new Vector3 { X = goal.Z, Y = 0, Z = goal.X };
+		Vector3 left = new Vector3(goal.Z, 0, goal.X);
 
-		left = Vector3.Multiply(Inverse(left), 1.0f / width);
+		left = Vector3.Normalize(left) / width;
 
 		Vector3 up = Vector3.Cross(goal, left);
-		Vector3 color = default(Vector3);
-		Vector3 adjust = default(Vector3);
+		Vector3 color = Vector3.Zero;
+		Vector3 adjust;
 
-		for (uint y = height; y > 0; y--)
-		{
-			for (uint x = width; x > 0; x--)
-			{
-				for (uint p = samples; p > 0; p--)
-				{
-					color = Vector3.Add(color, Trace(position, Vector3.Add(Inverse(Vector3.Multiply(Vector3.Add(goal, left), x - width / 2 + Random())), Vector3.Multiply(up, y - height / 2 + Random()))));
+		for (uint y = height; y > 0; y--) {
+			for (uint x = width; x > 0; x--) {
+				for (uint p = samples; p > 0; p--) {
+					color += Trace(position, Vector3.Normalize((goal + left) * (x - (width / 2) + Random())) + (up * (y - (height / 2) + Random())));
 				}
 
-				color = Vector3.Multiply(color, (1.0f / samples) + 14.0f / 241.0f);
-				adjust = AddFloat(color, 1.0f);
-				color = new Vector3 {
-					X = color.X / adjust.X,
-					Y = color.Y / adjust.Y,
-					Z = color.Z / adjust.Z
-				};
+				color *= (1.0f / samples) + (14.0f / 241.0f);
+				adjust = color + Vector3.One;
+				color /= adjust;
 
-				color = Vector3.Multiply(color, 255.0f);
+				color *= 255.0f;
 			}
 		}
 
@@ -67,100 +60,82 @@ public unsafe struct PixarRaytracerNET : IJob
 	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	private Vector3 Inverse(Vector3 vector) {
-		return Vector3.Multiply(vector, 1 / (float)Math.Sqrt(Vector3.Dot(vector, vector)));
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	private Vector3 AddFloat(Vector3 vector, float value) {
-		vector.X += value;
-		vector.Y += value;
-		vector.Z += value;
-
-		return vector;
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	private float Min(float left, float right) {
+	private static float Min(float left, float right) {
 		return left < right ? left : right;
 	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	private float BoxTest(Vector3 position, Vector3 lowerLeft, Vector3 upperRight) {
-		lowerLeft = Vector3.Multiply(Vector3.Add(position, lowerLeft), -1);
-		upperRight = Vector3.Multiply(Vector3.Add(upperRight, position), -1);
+	private static float BoxTest(Vector3 position, Vector3 lowerLeft, Vector3 upperRight) {
+		lowerLeft = -(position + lowerLeft);
+		upperRight = -(upperRight + position);
 
-		return -Min(Min(Min(lowerLeft.X, upperRight.X), Min(lowerLeft.Y, upperRight.Y)), Min(lowerLeft.Z, upperRight.Z));
+		Vector3 vmin = Vector3.Min(lowerLeft, upperRight);
+		return -Min(Min(vmin.X, vmin.Y), vmin.Z);
 	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	private float Random() {
-		marsagliaZ = 36969 * (marsagliaZ & 65535) + (marsagliaZ >> 16);
-		marsagliaW = 18000 * (marsagliaW & 65535) + (marsagliaW >> 16);
+	private static float Random() {
+		marsagliaZ = (36969 * (marsagliaZ & 65535)) + (marsagliaZ >> 16);
+		marsagliaW = (18000 * (marsagliaW & 65535)) + (marsagliaW >> 16);
 
 		return ((marsagliaZ << 16) + marsagliaW) * 2.0f / 10000000000.0f;
 	}
 
-	private float Sample(Vector3 position, int* hitType) {
-		const int size = 60;
+	private static ReadOnlySpan<float> letters => [
+		/* P */ 53, 79, 53, 95, 53, 87, 57, 87, 53, 95, 57, 95,
+		/* I */ 65, 79, 69, 79, 67, 79, 67, 95, 65, 95, 69, 95,
+		/* X */ 73, 79, 81, 95, 73, 95, 81, 79,
+		/* A */ 85, 79, 89, 95, 89, 95, 93, 79, 87, 87, 91, 87,
+		/* R */ 97, 79, 97, 95, 97, 87, 101, 87, 97, 95, 101, 95, 99, 87, 105, 79
+	];
 
+	private static float Sample(Vector3 position, int* hitType) {
 		float distance = 1e9f;
 		Vector3 f = position;
-		byte* letters = stackalloc byte[size];
-
-		// P              // I              // X              // A              // R
-		letters[0]  = 53; letters[12] = 65; letters[24] = 73; letters[32] = 85; letters[44] = 97; letters[56] = 99;
-		letters[1]  = 79; letters[13] = 79; letters[25] = 79; letters[33] = 79; letters[45] = 79; letters[57] = 87;
-		letters[2]  = 53; letters[14] = 69; letters[26] = 81; letters[34] = 89; letters[46] = 97; letters[58] = 105;
-		letters[3]  = 95; letters[15] = 79; letters[27] = 95; letters[35] = 95; letters[47] = 95; letters[59] = 79;
-		letters[4]  = 53; letters[16] = 67; letters[28] = 73; letters[36] = 89; letters[48] = 97;
-		letters[5]  = 87; letters[17] = 79; letters[29] = 95; letters[37] = 95; letters[49] = 87;
-		letters[6]  = 57; letters[18] = 67; letters[30] = 81; letters[38] = 93; letters[50] = 101;
-		letters[7]  = 87; letters[19] = 95; letters[31] = 79; letters[39] = 79; letters[51] = 87;
-		letters[8]  = 53; letters[20] = 65;                   letters[40] = 87; letters[52] = 97;
-		letters[9]  = 95; letters[21] = 95;                   letters[41] = 87; letters[53] = 95;
-		letters[10] = 57; letters[22] = 69;                   letters[42] = 91; letters[54] = 101;
-		letters[11] = 95; letters[23] = 95;                   letters[43] = 87; letters[55] = 95;
 
 		f.Z = 0.0f;
 
-		for (int i = 0; i < size; i += 4) {
-			Vector3 begin = Vector3.Multiply(new Vector3 { X = letters[i] - 79.0f, Y = letters[i + 1] - 79.0f, Z = 0.0f }, 0.5f);
-			Vector3 e = Vector3.Add(Vector3.Multiply(new Vector3 { X = letters[i + 2] - 79.0f, Y = letters[i + 3] - 79.0f, Z = 0.0f }, 0.5f), Vector3.Multiply(begin, -1.0f));
-			Vector3 o = Vector3.Multiply(Vector3.Add(f, Vector3.Multiply(Vector3.Add(begin, e), Min(-Min(Vector3.Dot(Vector3.Multiply(Vector3.Add(begin, f), -1.0f), e) / Vector3.Dot(e, e), 0.0f), 1.0f))), -1.0f);
+		for (int i = 0; i < letters.Length; i += 4) {
+			// The JIT isn't quite smart enough to elide the bounds
+			// checks and so we'll help it out a little bit instead.
+			ref float letter = ref Unsafe.AsRef(in letters[i]);
 
-			distance = Min(distance, Vector3.Dot(o, o));
+			Vector3 begin = new Vector3((Unsafe.As<float, Vector2>(ref letter) - new Vector2(79.0f)) * 0.5f, 0.0f);
+			Vector3 e = new Vector3((Unsafe.As<float, Vector2>(ref Unsafe.Add(ref letter, 2)) - new Vector2(79.0f)) * 0.5f, 0.0f) - begin;
+			Vector3 o = -(f + ((begin + e) * Min(-Min(Vector3.Dot(-(begin + f), e) / e.LengthSquared(), 0.0f), 1.0f)));
+
+			distance = Min(distance, o.LengthSquared());
 		}
 
-		distance = (float)Math.Sqrt(distance);
+		distance = float.Sqrt(distance);
 
-		Span<Vector3> curves = stackalloc Vector3[2];
+		Span<Vector3> curves = [
+			new Vector3(11.0f, 6.0f, 0.0f),
+			new Vector3(-11.0f, 6.0f, 0.0f),
+		];
 
-		curves[0] = new Vector3 { X = -11.0f, Y = 6.0f, Z = 0.0f };
-		curves[1] = new Vector3 { X = 11.0f, Y = 6.0f, Z = 0.0f };
-
-		for (int i = 1; i >= 0; i--) {
-			Vector3 o = Vector3.Add(f, Vector3.Multiply(curves[i], -1.0f));
+		for (int i = 0; i < curves.Length; i++) {
+			Vector3 o = f - curves[i];
 			float m = 0.0f;
 
 			if (o.X > 0.0f) {
-				m = (float)Math.Abs(Math.Sqrt(Vector3.Dot(o, o)) - 2.0f);
+				m = float.Abs(o.Length() - 2.0f);
 			} else {
 				if (o.Y > 0.0f)
 					o.Y += -2.0f;
 				else
 					o.Y += 2.0f;
 
-				o.Y += (float)Math.Sqrt(Vector3.Dot(o, o));
+				o.Y += o.Length();
 			}
 
 			distance = Min(distance, m);
 		}
 
-		distance = (float)Math.Pow(Math.Pow(distance, 8.0f) + Math.Pow(position.Z, 8.0f), 0.125f) - 0.5f;
+		distance = float.Pow(float.Pow(distance, 8.0f) + float.Pow(position.Z, 8.0f), 0.125f) - 0.5f;
 		*hitType = (int)PixarRayHit.Letter;
 
-		float roomDistance = Min(-Min(BoxTest(position, new Vector3 { X = -30.0f, Y = -0.5f, Z = -30.0f }, new Vector3 { X = 30.0f, Y = 18.0f, Z = 30.0f }), BoxTest(position, new Vector3 { X = -25.0f, Y = -17.5f, Z = -25.0f }, new Vector3 { X = 25.0f, Y = 20.0f, Z = 25.0f })), BoxTest( new Vector3 { X = Math.Abs(position.X) % 8, Y = position.Y, Z = position.Z }, new Vector3 { X = 1.5f, Y = 18.5f, Z = -25.0f }, new Vector3 { X = 6.5f, Y = 20.0f, Z = 25.0f }));
+		float roomDistance = Min(-Min(BoxTest(position, new Vector3(-30.0f, -0.5f, -30.0f), new Vector3(30.0f, 18.0f, 30.0f)), BoxTest(position, new Vector3(-25.0f, -17.5f, -25.0f), new Vector3(25.0f, 20.0f, 25.0f))), BoxTest(new Vector3(float.Abs(position.X) % 8, position.Y, position.Z), new Vector3(1.5f, 18.5f, -25.0f), new Vector3(6.5f, 20.0f, 25.0f)));
 
 		if (roomDistance < distance) {
 			distance = roomDistance;
@@ -177,17 +152,17 @@ public unsafe struct PixarRaytracerNET : IJob
 		return distance;
 	}
 
-	private int RayMarching(Vector3 origin, Vector3 direction, Vector3* hitPosition, Vector3* hitNormal) {
+	private static int RayMarching(Vector3 origin, Vector3 direction, Vector3* hitPosition, Vector3* hitNormal) {
 		int hitType = (int)PixarRayHit.None;
 		int noHitCount = 0;
 		float distance = 0.0f;
 
 		for (float i = 0; i < 100; i += distance) {
-			*hitPosition = Vector3.Multiply(Vector3.Add(origin, direction), i);
+			*hitPosition = (origin + direction) * i;
 			distance = Sample(*hitPosition, &hitType);
 
 			if (distance < 0.01f || ++noHitCount > 99) {
-				*hitNormal = Inverse(new Vector3 { X = Sample(Vector3.Add(*hitPosition, new Vector3 { X = 0.01f, Y = 0.0f, Z = 0.0f }), &noHitCount) - distance, Y = Sample(Vector3.Add(*hitPosition, new Vector3 { X = 0.0f, Y = 0.01f, Z = 0.0f }), &noHitCount) - distance, Z = Sample(Vector3.Add(*hitPosition, new Vector3 { X = 0.0f, Y = 0.0f, Z = 0.01f }), &noHitCount) - distance });
+				*hitNormal = Vector3.Normalize(new Vector3(Sample(*hitPosition + new Vector3(0.01f, 0.0f, 0.0f), &noHitCount) - distance, Sample(*hitPosition + new Vector3(0.0f, 0.01f, 0.0f), &noHitCount) - distance, Sample(*hitPosition + new Vector3(0.0f, 0.0f, 0.01f), &noHitCount) - distance));
 
 				return hitType;
 			}
@@ -196,16 +171,14 @@ public unsafe struct PixarRaytracerNET : IJob
 		return (int)PixarRayHit.None;
 	}
 
-	private Vector3 Trace(Vector3 origin, Vector3 direction) {
-		Vector3
-			sampledPosition = new Vector3 { X = 1.0f, Y = 1.0f, Z = 1.0f },
-			normal = new Vector3 { X = 1.0f, Y = 1.0f, Z = 1.0f },
-			color = new Vector3 { X = 1.0f, Y = 1.0f, Z = 1.0f },
-			attenuation = new Vector3 { X = 1.0f, Y = 1.0f, Z = 1.0f },
-			lightDirection = Inverse(new Vector3 { X = 0.6f, Y = 0.6f, Z = 1.0f });
+	private static Vector3 Trace(Vector3 origin, Vector3 direction) {
+		Vector3 sampledPosition = Vector3.One;
+		Vector3 normal = Vector3.One;
+		Vector3 color = Vector3.One;
+		Vector3 attenuation = Vector3.One;
+		Vector3 lightDirection = Vector3.Normalize(new Vector3(0.6f, 0.6f, 1.0f));
 
-		for (int bounce = 3; bounce > 0; bounce--)
-		{
+		for (int bounce = 3; bounce > 0; bounce--) {
 			PixarRayHit hitType = (PixarRayHit)RayMarching(origin, direction, &sampledPosition, &normal);
 
 			switch (hitType) {
@@ -214,44 +187,40 @@ public unsafe struct PixarRaytracerNET : IJob
 
 				case PixarRayHit.Letter:
 				{
-					direction = Vector3.Multiply(Vector3.Add(direction, normal), Vector3.Dot(normal, direction) * -2.0f);
-					origin = Vector3.Multiply(Vector3.Add(sampledPosition, direction), 0.1f);
-					attenuation = Vector3.Multiply(attenuation, 0.2f);
+					direction = (direction + normal) * (Vector3.Dot(normal, direction) * -2.0f);
+					origin = (sampledPosition + direction) * 0.1f;
+					attenuation *= 0.2f;
 
 					break;
 				}
 
 				case PixarRayHit.Wall:
 				{
-					float
-						incidence = Vector3.Dot(normal, lightDirection),
-						p = 6.283185f * Random(),
-						c = Random(),
-						s = (float)Math.Sqrt(1.0f - c),
-						g = normal.Z < 0 ? -1.0f : 1.0f,
-						u = -1.0f / (g + normal.Z),
-						v = normal.X * normal.Y * u;
+					float incidence = Vector3.Dot(normal, lightDirection);
+					float p = 6.283185f * Random();
+					float c = Random();
+					float s = float.Sqrt(1.0f - c);
+					float g = (normal.Z < 0) ? -1.0f : 1.0f;
+					float u = -1.0f / (g + normal.Z);
+					float v = normal.X * normal.Y * u;
 
-					direction = Vector3.Add(Vector3.Add(new Vector3 { X = v, Y = g + normal.Y * normal.Y * u, Z = -normal.Y * ((float)Math.Cos(p) * s) }, new Vector3 { X = 1.0f + g * normal.X * normal.X * u, Y = g * v, Z = -g * normal.X }), Vector3.Multiply(normal, (float)Math.Sqrt(c)));
-					origin = Vector3.Multiply(Vector3.Add(sampledPosition, direction), 0.1f);
-					attenuation = Vector3.Multiply(attenuation, 0.2f);
+					direction = new Vector3(v, g + (normal.Y * normal.Y * u), -normal.Y * (float.Cos(p) * s)) + new Vector3(1.0f + (g * normal.X * normal.X * u), g * v, -g * normal.X) + (normal * float.Sqrt(c));
+					origin = (sampledPosition + direction) * 0.1f;
+					attenuation *= 0.2f;
 
-					if (incidence > 0 && RayMarching(Vector3.Multiply(Vector3.Add(sampledPosition, normal), 0.1f), lightDirection, &sampledPosition, &normal) == (int)PixarRayHit.Sun)
-						color = Vector3.Multiply(Vector3.Multiply(Vector3.Add(color, attenuation), new Vector3 { X = 500.0f, Y = 400.0f, Z = 100.0f }), incidence);
+					if (incidence > 0 && RayMarching((sampledPosition + normal) * 0.1f, lightDirection, &sampledPosition, &normal) == (int)PixarRayHit.Sun)
+						color = (color + attenuation) * new Vector3(500.0f, 400.0f, 100.0f) * incidence;
 
 					break;
 				}
 
 				case PixarRayHit.Sun:
 				{
-					color = Vector3.Multiply(Vector3.Add(color, attenuation), new Vector3 { X = 50.0f, Y = 80.0f, Z = 100.0f });
-
-					goto escape;
+					color = (color + attenuation) * new Vector3(50.0f, 80.0f, 100.0f);
+					return color;
 				}
 			}
 		}
-
-		escape:
 
 		return color;
 	}

--- a/NET_project/Benchmarks/Polynomials.cs
+++ b/NET_project/Benchmarks/Polynomials.cs
@@ -1,5 +1,8 @@
-﻿namespace NET_project.Benchmarks;
+﻿using System.Runtime.CompilerServices;
 
+namespace NET_project.Benchmarks;
+
+[SkipLocalsInit]
 public unsafe struct PolynomialsNET : IJob
 {
 	public uint iterations;
@@ -9,26 +12,24 @@ public unsafe struct PolynomialsNET : IJob
 		result = Polynomials(iterations);
 	}
 
-	private float Polynomials(uint iterations)
-	{
+	private static float Polynomials(uint iterations) {
 		const float x = 0.2f;
 
 		float pu = 0.0f;
-		float* poly = stackalloc float[100];
+		Span<float> poly = stackalloc float[100];
 
 		for (uint i = 0; i < iterations; i++) {
 			float mu = 10.0f;
-			float s;
-			int j;
 
-			for (j = 0; j < 100; j++) {
-				poly[j] = mu = (mu + 2.0f) / 2.0f;
+			for (int j = 0; j < poly.Length; j++) {
+				mu = (mu + 2.0f) / 2.0f;
+				poly[j] = mu;
 			}
 
-			s = 0.0f;
+			float s = 0.0f;
 
-			for (j = 0; j < 100; j++) {
-				s = x * s + poly[j];
+			for (int j = 0; j < poly.Length; j++) {
+				s = (x * s) + poly[j];
 			}
 
 			pu += s;

--- a/NET_project/Benchmarks/Seahash.cs
+++ b/NET_project/Benchmarks/Seahash.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace NET_project.Benchmarks;
 
@@ -6,53 +7,57 @@ public unsafe struct SeahashNET : IJob {
 	public uint iterations;
 	public ulong result;
 
-	public void Run()
-	{
+	public void Run() {
 		result = Seahash(iterations);
 	}
 
-	private ulong Seahash(uint Iterations)
-	{
+	private static ulong Seahash(uint Iterations) {
 		const int bufferLength = 1024 * 128;
 
-		byte[] buffer = new byte[bufferLength];
+		// Using span here would be more complex due to it unsafely reading
+		// 8 byte pieces of data and depending on alignment to make overreading
+		// it does "safe".
+		byte* buffer = (byte*)NativeMemory.AlignedAlloc(bufferLength, 8);
 
-		for (int i = 0; i < bufferLength; i++)
-		{
+		for (int i = 0; i < bufferLength; i++) {
 			buffer[i] = (byte)(i % 256);
 		}
 
 		ulong hash = 0;
 
-		for (uint i = 0; i < Iterations; i++)
-		{
+		for (uint i = 0; i < Iterations; i++) {
 			hash = Compute(buffer, bufferLength, 0x16F11FE89B0D677C, 0xB480A793D8E6C86C, 0x6FE2E5AAF078EBC9, 0x14F994A4C5259381);
 		}
+
+		NativeMemory.AlignedFree(buffer);
 
 		return hash;
 	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	private ulong Diffuse(ulong value)
-	{
+	private static ulong Read(byte* pointer) {
+		return *(ulong*)pointer;
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	private static ulong Diffuse(ulong value) {
 		value *= 0x6EED0E9DA4D94A4F;
-		value ^= ((value >> 32) >> (int)(value >> 60));
+		value ^= value >> 32 >> (int)(value >> 60);
 		value *= 0x6EED0E9DA4D94A4F;
 
 		return value;
 	}
 
-	private ulong Compute(byte[] buffer, ulong length, ulong a, ulong b, ulong c, ulong d)
-	{
+	private static ulong Compute(byte* buffer, ulong length, ulong a, ulong b, ulong c, ulong d) {
 		const uint blockSize = 32;
 
 		ulong end = length & ~(blockSize - 1);
 
 		for (uint i = 0; i < end; i += blockSize) {
-			a ^= buffer[i];
-			b ^= buffer[i + 8];
-			c ^= buffer[i + 16];
-			d ^= buffer[i + 24];
+			a ^= Read(buffer + i);
+			b ^= Read(buffer + i + 8);
+			c ^= Read(buffer + i + 16);
+			d ^= Read(buffer + i + 24);
 
 			a = Diffuse(a);
 			b = Diffuse(b);
@@ -61,22 +66,19 @@ public unsafe struct SeahashNET : IJob {
 		}
 
 		ulong excessive = length - end;
+		byte* bufferEnd = buffer + end;
 
-		if (excessive > 0)
-		{
-			a ^= buffer[^1];
+		if (excessive > 0) {
+			a ^= Read(bufferEnd);
 
-			if (excessive > 8)
-			{
-				b ^= buffer[^1];
+			if (excessive > 8) {
+				b ^= Read(bufferEnd);
 
-				if (excessive > 16)
-				{
-					c ^= buffer[^1];
+				if (excessive > 16) {
+					c ^= Read(bufferEnd);
 
-					if (excessive > 24)
-					{
-						d ^= buffer[^1];
+					if (excessive > 24) {
+						d ^= Read(bufferEnd);
 						d = Diffuse(d);
 					}
 

--- a/NET_project/Benchmarks/SieveOfEratosthenes.cs
+++ b/NET_project/Benchmarks/SieveOfEratosthenes.cs
@@ -1,5 +1,8 @@
-﻿namespace NET_project.Benchmarks;
+﻿using System.Runtime.CompilerServices;
 
+namespace NET_project.Benchmarks;
+
+[SkipLocalsInit]
 public unsafe struct SieveOfEratosthenesNET : IJob {
 	public uint iterations;
 	public uint result;
@@ -8,27 +11,21 @@ public unsafe struct SieveOfEratosthenesNET : IJob {
 		result = SieveOfEratosthenes(iterations);
 	}
 
-	private uint SieveOfEratosthenes(uint iterations) {
-		const int size = 1024;
+	private static uint SieveOfEratosthenes(uint iterations) {
+		Span<byte> flags = stackalloc byte[1024];
+		uint count = 0;
 
-		byte* flags = stackalloc byte[size];
-		uint a, b, c, prime, count = 0;
-
-		for (a = 1; a <= iterations; a++) {
+		for (uint a = 1; a <= iterations; a++) {
 			count = 0;
 
-			for (b = 0; b < size; b++) {
-				flags[b] = 1; // True
-			}
+			flags.Fill(1);
 
-			for (b = 0; b < size; b++) {
-				if (flags[b] == 1) {
-					prime = b + b + 3;
-					c = b + prime;
+			for (uint b = 0; b < flags.Length; b++) {
+				if (flags[(int)b] == 1) {
+					uint prime = b + b + 3;
 
-					while (c < size) {
-						flags[c] = 0; // False
-						c += prime;
+					for (uint c = b + prime; c < flags.Length; c += prime) {
+						flags[(int)c] = 0;
 					}
 
 					count++;


### PR DESCRIPTION
This just does a very basic cleanup of the .NET implementations. In many cases, it's just marking methods as `static`, moving variables around to help with JIT analysis (manual hoisting outside of loops), or ensuring that the array.Length is used as the loop bounds.

Where it was possible to use safe code (such as `Span<T>`) that was preferred. However, there are a couple places where the logic in question is complex enough that the JIT (and even C/C++ compilers, if you add bounds checking) can't readily determine its "safe" and so the code sticks with pointers. It would be possible to use `ref arithmetic` via the `Unsafe` class, but that doesn't really improve safety at all.

The other biggest change is simply ensuring that the actual `Vector3` APIs and operators are used where possible. This improves the code quality quite a bit in a few cases.

I've shared some basic numbers below showing what MSVC vs .NET 8 vs this PR show on my own box. -- It's actually possible to do more work and improve the code quality a lot more for .NET, but I didn't want to deviate from the C implementation "too much", particularly where there wasn't an API built-in. I tried to keep it as idiomatic as possible.

# AMD Ryzen 9 7950X, 1 CPU, 32 logical and 16 physical cores

## MSVC v143

(MS) Fibonacci: 50928251 ticks. Result: 2971215073
(MS) Mandelbrot: 16983558 ticks. Result: 4.1998944
(MS) NBody: 43088548 ticks. Result: 7.978854149829663E-05
(MS) Sieve of Eratosthenes: 8329654 ticks. Result: 308
(MS) Pixar Raytracer: 73259295 ticks. Result: 741.63477
(MS) Fireflies Flocking: 50781152 ticks. Result: 1.0151153E+09
(MS) Polynomials: 16732104 ticks. Result: 21677722
(MS) Particle Kinematics: 55025771 ticks. Result: 64407596
(MS) Arcfour: 48197332 ticks. Result: 10
(MS) Seahash: 142456480 ticks. Result: 11468720252350332299
(MS) Radix: 18431283 ticks. Result: 668

## .NET 8.0 - Main

(RyuJIT) Fibonacci: 35061028 ticks. Result: 2971215073
(RyuJIT) Mandelbrot: 18016053 ticks. Result: 4.1998944
(RyuJIT) NBody: 46486741 ticks. Result: 7.978854149829663E-05
(RyuJIT) Sieve of Eratosthenes: 10151184 ticks. Result: 308
(RyuJIT) Pixar Raytracer: 83528645 ticks. Result: 741.63477
(RyuJIT) Fireflies Flocking: 58851659 ticks. Result: 1.0151153E+09
(RyuJIT) Polynomials: 16503048 ticks. Result: 21677722
(RyuJIT) Particle Kinematics: 63527972 ticks. Result: 64407596
(RyuJIT) Arcfour: 61476329 ticks. Result: 10
(RyuJIT) Seahash: 133892925 ticks. Result: 1575736758465698443
(RyuJIT) Radix: 82558085 ticks. Result: 668

## .NET 8.0 - PR

(RyuJIT) Fibonacci: 30648491 ticks. Result: 2971215073
(RyuJIT) Mandelbrot: 15781488 ticks. Result: 4.1998944
(RyuJIT) NBody: 45494417 ticks. Result: 7.978854149829663E-05
(RyuJIT) Sieve of Eratosthenes: 7826368 ticks. Result: 308
(RyuJIT) Pixar Raytracer: 56617341 ticks. Result: 741.63477
(RyuJIT) Fireflies Flocking: 56970786 ticks. Result: 1.0151153E+09
(RyuJIT) Polynomials: 16370985 ticks. Result: 21677722
(RyuJIT) Particle Kinematics: 48251143 ticks. Result: 64407596
(RyuJIT) Arcfour: 51839147 ticks. Result: 10
(RyuJIT) Seahash: 107570446 ticks. Result: 11468720252350332299
(RyuJIT) Radix: 22400430 ticks. Result: 668
